### PR TITLE
FrameworkReference Warning fixed 

### DIFF
--- a/IMDB.csproj
+++ b/IMDB.csproj
@@ -3,9 +3,6 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="ElectronNet.API" Version="11.5.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.4" />


### PR DESCRIPTION
Removed the "Microsoft.AspNetCore.App" reference so now the build is warning-free.
Closes #18 